### PR TITLE
Update a11y.md

### DIFF
--- a/content/projects-using-vue-js/a11y.md
+++ b/content/projects-using-vue-js/a11y.md
@@ -28,7 +28,6 @@ meta:
 - [vue-skip-to](https://github.com/vue-a11y/vue-skip-to) - It helps people who only use the keyboard to jump to what matters most.
 - [vue-axe](https://github.com/vue-a11y/vue-axe) - Accessibility auditing for Vue.js applications.
 - [vue-announcer](https://github.com/vue-a11y/vue-announcer) - A simple way with Vue to announce any useful information for screen readers.
-- [eslint-plugin-vue-a11y](https://github.com/maranran/eslint-plugin-vue-a11y) - Static AST checker for accessibility rules on elements in .vue
 - [vue-focus-lock](https://github.com/theKashey/vue-focus-lock) - It is a trap! A lock for a Focus. A11y util for scoping a focus.
 - [vue-a11y-calendar](https://github.com/IBM/vue-a11y-calendar) - Accessible, internationalized Vue calendar.
 - [eslint-plugin-vuejs-accessibility](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility) - Vue.js accessibility eslint-plugin managed by [vue-a11y](https://github.com/vue-a11y).


### PR DESCRIPTION
`eslint-plugin-vue-a11y` has been deprecated in favour of `eslint-plugin-vuejs-accessibility`.

https://github.com/maranran/eslint-plugin-vue-a11y/issues/28#issuecomment-633150519