### PR TITLE
Add Vuedoc

### DIFF
--- a/content/components-and-libraries/dev-tools.md
+++ b/content/components-and-libraries/dev-tools.md
@@ -49,6 +49,8 @@ Inspecting & debugging
 Create documentation
 
 - [vue-styleguidist](https://github.com/vue-styleguidist/vue-styleguidist) - A style guide generator for Vue components with a living style guide.
+- [Vuedoc Markdown](https://gitlab.com/vuedoc/md) - Generate a Markdown Documentation for a Vue Component
+- [Vuedoc Parser](https://gitlab.com/vuedoc/parser) - Generate a JSON documentation for a Vue component
 
 ## Test
 


### PR DESCRIPTION
This adds Vuedoc on the docs section, which is a tool to generate a documentation for Vue 2 and 3.