### PR TITLE
docs: add Vue3 Pivottable and remove vue-datamaps

### DIFF
--- a/content/components-and-libraries/ui-components.md
+++ b/content/components-and-libraries/ui-components.md
@@ -40,6 +40,7 @@ head:
 Tables / data grids
 
 - [vue-cheetah-grid](https://github.com/future-architect/cheetah-grid) - A high-performance grid engine that work on a canvas for Vue.js.
+- [Vue3 Pivottable](https://github.com/vue-pivottable/vue3-pivottable) - A Vue 3 port of the jQuery-based PivotTable.js library.
 
 ## Notification
 

--- a/content/projects-using-vue-js/open-source.md
+++ b/content/projects-using-vue-js/open-source.md
@@ -199,7 +199,6 @@ head:
 - [miniPress](https://christiankienle.github.io/minipress/) - Yet another static site generator
 - [Zeithub](https://github.com/m0g/zeithub) - Open source time tracking, invoicing & expenses management for freelancers
 - [CodeceptJS UI](https://github.com/codecept-js/ui) - Cypress-liked UI for CodeceptJS end 2 end tests
-- [Vue3 Pivottable](https://github.com/vue-pivottable/vue3-pivottable) - A Vue 3 port of the jQuery-based PivotTable.js library.
 - [Marked.cc](https://github.com/msjaber/marked.cc) - Create and share beautiful images of your notes and prose
 - [LeagueStats](https://github.com/vkaelin/LeagueStats) - Statistics website for players of the online game League of Legends
 - [Veniqa](https://github.com/Viveckh/Veniqa) - An E-commerce solution with a shopping client and admin panel written in Vue

--- a/content/projects-using-vue-js/open-source.md
+++ b/content/projects-using-vue-js/open-source.md
@@ -199,8 +199,7 @@ head:
 - [miniPress](https://christiankienle.github.io/minipress/) - Yet another static site generator
 - [Zeithub](https://github.com/m0g/zeithub) - Open source time tracking, invoicing & expenses management for freelancers
 - [CodeceptJS UI](https://github.com/codecept-js/ui) - Cypress-liked UI for CodeceptJS end 2 end tests
-- [Vue Pivottable](https://github.com/Seungwoo321/vue-pivottable) - Vue port of the jQuery-based PivotTable.js
-- [Vue Datamaps](https://github.com/Seungwoo321/vue-datamaps) - Vue port of the javascript-based DataMaps
+- [Vue3 Pivottable](https://github.com/vue-pivottable/vue3-pivottable) - A Vue 3 port of the jQuery-based PivotTable.js library.
 - [Marked.cc](https://github.com/msjaber/marked.cc) - Create and share beautiful images of your notes and prose
 - [LeagueStats](https://github.com/vkaelin/LeagueStats) - Statistics website for players of the online game League of Legends
 - [Veniqa](https://github.com/Viveckh/Veniqa) - An E-commerce solution with a shopping client and admin panel written in Vue


### PR DESCRIPTION
# Please Read

## Link Submission

Please submit your link(s) to the [official Vue.js Awesome List](https://github.com/vuejs/awesome-vue) repository (read first their [contributing guide](https://github.com/vuejs/awesome-vue/blob/master/.github/contributing.md)).

If they merge your pull request there, it will also be updated in this repository.

_But if you really want to add it here, I would still review it._

## Bug Fix or New Feature

For bug fixes or new features to this repository, delete this template text and proceed to provide information about the changes introduced in this pull request.

## Contribution Agreement

By submitting a pull request to this repository, you are accepting this contribution agreement:

> I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.


---

## Summary of changes
- ✅ Added: Vue3 Pivottable – A Vue 3 port of the jQuery-based PivotTable.js library.
- ❌ Removed: vue-datamaps – Does not support Vue 3.

## Reason

- The vue-datamaps project is not compatible with Vue 3, so it has been removed.
- The Vue3 Pivottable project is a new repository created to support Vue 3, based on the original vue-pivottable implementation.